### PR TITLE
Implemented suggestion from Clippy

### DIFF
--- a/src/avl_tree.rs
+++ b/src/avl_tree.rs
@@ -4,7 +4,7 @@ use avl_node::Node;
 
 mod avl_node;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct AvlTree {
     root: Option<Node>,
 }


### PR DESCRIPTION
Clippy suggested implementing `Default` for the `AvlTree` since I have `new` implemented. Once I had implemented `Default`, it suggested I could just derive `Default` instead.